### PR TITLE
ci: re-enable run_all_checks workflows

### DIFF
--- a/.github/workflows/run_all_checks_unix.yml
+++ b/.github/workflows/run_all_checks_unix.yml
@@ -7,22 +7,6 @@ on:
 
 jobs:
   run-all-checks-unix:
-    name: Run All Checks (Unix placeholder)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run placeholder unix checks
-        run: |
-          echo "Running unix checks (placeholder)"
-name: Run All Checks (Unix)
-permissions:
-  contents: read
-
-on:
-  workflow_dispatch: {}
-
-jobs:
-  run-all-checks-unix:
     name: Run All Checks on Unix
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Restore run_all_checks and aggregator workflows to allow CI dispatch + aggregator visibility. These are minimal placeholder workflows; we can iterate on aggregator retention and annotations.